### PR TITLE
Default list now shows parent names

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -18,7 +18,7 @@
     <ul>
         {{ range .Pages }}
         <li>
-            <a href="{{ .Permalink }}">{{ if .Draft }}DRAFT: {{end}}{{ .Title | markdownify }}</a>
+            <a href="{{ .Permalink }}">{{ if .Draft }}DRAFT: {{end}}{{ .Parent.Title }}, {{ .Title | markdownify }}</a>
             <time class="date-meta">{{ .Date.Format "Jan 2" }}</time>
         </li>
         {{ end }}


### PR DESCRIPTION
Fixes deathworlders/online#64.

It may be desirable to not show titles when we're in a book's directory, but doing that will take more digging than I'm willing to do at the moment.