### PR TITLE
Show titles in all lists, redux

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -18,7 +18,7 @@
     <ul>
         {{ range .Pages }}
         <li>
-            <a href="{{ .Permalink }}">{{ if .Draft }}DRAFT: {{end}}{{ .Parent.Title }}<br>{{ .Title | markdownify }}</a>
+            <a href="{{ .Permalink }}">{{ if .Draft }}DRAFT: {{end}}{{ .Parent.Title }}<br/>{{ .Title | markdownify }}</a>
             <time class="date-meta">{{ .Date.Format "Jan 2" }}</time>
         </li>
         {{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -18,7 +18,7 @@
     <ul>
         {{ range .Pages }}
         <li>
-            <a href="{{ .Permalink }}">{{ if .Draft }}DRAFT: {{end}}{{ .Parent.Title }}, {{ .Title | markdownify }}</a>
+            <a href="{{ .Permalink }}">{{ if .Draft }}DRAFT: {{end}}{{ .Parent.Title }}<br>{{ .Title | markdownify }}</a>
             <time class="date-meta">{{ .Date.Format "Jan 2" }}</time>
         </li>
         {{ end }}


### PR DESCRIPTION
Changed commas to HTML breaks, since it looks cleaner.

To people cleaning this up in the future: ideally, we'd do this via CSS classes instead of HTML breaks.  If you can make the CSS do the thing, please have at it.  (Future!me, for one, would be grateful.)