### PR TITLE
Fixes cover image popup in inverted mode

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -467,3 +467,7 @@ body.inverted blockquote {
 .download-epub-cover-selector-popup img.hidden  {
   display:none;
 }
+
+body.inverted .download-epub-cover-selector-popup {
+  background-color:#222 !important; /* very nearly black */
+}


### PR DESCRIPTION
Fixes the background color of the epub cover image selector popup while in inverted mode

before:
![image](https://user-images.githubusercontent.com/1485728/50628386-34cdd280-0f38-11e9-9a31-9475722eb451.png)
after:
![image](https://user-images.githubusercontent.com/1485728/50628398-3dbea400-0f38-11e9-8169-3a39900ee007.png)
