### PR TITLE
Removes body text color on epub generation.

### DIFF
--- a/static/js/epub-generator.js
+++ b/static/js/epub-generator.js
@@ -182,6 +182,9 @@
 
 								// get the title and print it for debugging purposes
 								//console.log("DOWNLOADED:",parent.getElementsByTagName("article")[0].getElementsByTagName("h1")[0].innerHTML);
+								
+								// The #333333 color is very annoying on some Kindle models so this removes the color tag completely on body text.
+								css_file = css_file.replace("color: #333333", "");
 
 								// position:absolute; is not allowed in EPUB
 								// blockquote::before contains this tag


### PR DESCRIPTION
The styles used for the body and the ebook are the same. The body has a grayish text color of `#333333` which may be good design on a website but not an ebook. This pull request adds a line to replace `color: #333333` with nothing to remove it.

On some older Kindle models this color persists and causes the text to be slightly above black - not desired on an E-Ink screen. This change removes the color completely so as to let the Kindle/conversion software determine the color automatically.